### PR TITLE
Updating the allowed site

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	e := echo.New()
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig {
-  		AllowOrigins: []string{"http://localhost:5173"},
+  		AllowOrigins: []string{"https://nazime1.github.io/"},
   		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
 	}))
 


### PR DESCRIPTION
Since the textbook is hosted on GitHub Pages and not localhost anymore, main.go should be updated to support it.